### PR TITLE
Added more efficient and readable bitwise operation

### DIFF
--- a/ASAN/Source/functions.h
+++ b/ASAN/Source/functions.h
@@ -80,7 +80,7 @@ bool IsNonCaseSymbolsMatch(int player_name[], char *connected_name)
 	{
 		int sym_str2 = (int)*connected_name;
 		if (sym_str2 < 0)
-			sym_str2 = (256 + sym_str2);
+			sym_str2 &= 0xFF;
 		connected_name++;
 		if (player_name[i] != sym_str2 && (player_name[i] - 32) != sym_str2 && player_name[i] != (sym_str2 - 32) && (player_name[i] - 16) != sym_str2 && player_name[i] != (sym_str2 - 16))
 			return false;
@@ -98,7 +98,7 @@ bool IsCaseSymbolsMatch(int player_name[], char *connected_name)
 	{
 		int sym_str2 = (int)*connected_name;
 		if (sym_str2 < 0)
-			sym_str2 = (256 + sym_str2);
+			sym_str2 &= 0xFF;
 		connected_name++;
 
 		if (player_name[i] != sym_str2)
@@ -283,7 +283,7 @@ void ShowErrorMessage(char hook_name[], int error_code)
 	if (Plugin_Config.Language == 0)
 		logprintf("\t[ASAN | %s | ERROR]:\tError code - 0x%x*\t->Missing..", hook_name, error_code);
 	else
-		logprintf("\t[ASAN | %s | Œÿ»¡ ¿]:\t Ó‰ Ó¯Ë·ÍË - 0x%x*\t->œÓÔÛÒÍ‡ÂÏ..", hook_name, error_code);
+		logprintf("\t[ASAN | %s | √é√ò√à√Å√ä√Ä]:\t√ä√Æ√§ √Æ√∏√®√°√™√® - 0x%x*\t->√è√∞√Æ√Ø√≥√±√™√†√•√¨..", hook_name, error_code);
 }
 
 void ShowCopiratesInfo()
@@ -295,7 +295,7 @@ void ShowCopiratesInfo()
 	}
 	else
 	{
-		logprintf("\t[ASAN | —¿…“]:\t\thttps://github.com/KrYpToDeN/Advanced-SA-NickName");
+		logprintf("\t[ASAN | √ë√Ä√â√í]:\t\thttps://github.com/KrYpToDeN/Advanced-SA-NickName");
 		logprintf("\t------------------------------------------------------------------\n\n");
 	}
 }

--- a/ASAN/Source/pawn_hook.h
+++ b/ASAN/Source/pawn_hook.h
@@ -12,7 +12,7 @@ cell AMX_NATIVE_CALL ASAN_HOOK_ConnectPlayer(AMX* amx, cell* params)
 	{
 		int sym_str = (int)name[i];
 		if (sym_str < 0)
-			sym_str = (256 + sym_str);
+			sym_str &= 0xFF;
 		PlayerInfo[playerID].PlayerName[i] = sym_str;
 	}
 	PlayerInfo[playerID].PlayerName[name_strlen] = EOF;
@@ -41,7 +41,7 @@ cell AMX_NATIVE_CALL ASAN_HOOK_GetPlayerName(AMX *amx, cell *params)
 	{
 		if (destination[len] < 0)
 		{
-			destination[len] += 256;
+			destination[len] &= 0xFF;
 		}
 		len++;
 	}


### PR DESCRIPTION
As far as I know this is needed since SAMP likes to append `0xFFFFFF` behind ASCII chars. This bitwise operation obtains the same result as doing += 256, but it's a bit more optimized and more readable. Since the only chars we expect are only 1 byte long, this bitwise operation retrieves only that last byte, which is what we want, and leave those buggy FF bytes aside:

```PAWN
new BuggedSAMPChar = 0xFFFFFF41; //This is what the SA-MP would return for 'A'.
BuggedSAMPChar &= 0xFF; //only retrieve last bytes
```
The result of this would be a proper 0x41, which is what we want.