### PR TITLE
Try supporting Unicode regular expression syntax

### DIFF
--- a/ASAN/src/functions.cpp
+++ b/ASAN/src/functions.cpp
@@ -99,13 +99,35 @@ bool IsValidReplaceSpacesRules(char name[]) // Cheking first and last symbols in
 	return true;
 }
 
+// String is converted to a multi-byte string
+std::wstring s2ws(const std::string& s)
+{
+	// Temporarily configure the locale
+	// The Chinese character set for Windows is GBK
+	setlocale(LC_ALL, "zh_CN.GBK");
+	const char* _Source = s.c_str();
+	size_t _Dsize = s.size() + 1;
+	wchar_t* _Dest = new wchar_t[_Dsize];
+	wmemset(_Dest, 0, _Dsize);
+	mbstowcs(_Dest, _Source, _Dsize);
+	std::wstring result = _Dest;
+	delete[]_Dest;
+	// Restoring the Default locale
+	setlocale(LC_ALL, "C");
+	return result;
+}
+
 int HOOK_ValidNickName(char *name) // Thanks to [EC]Zero for helping with this hook
 {
 	int name_length = strlen(name);
 	if (name_length < NickLength_Config.MinNickLength || name_length > NickLength_Config.MaxNickLength)
 		return 1; // DON'T Allow Connection
 
-	if (std::regex_match(name, ValidNick_Config.RegexTemplate))
+	// Attempts to convert a character to a multi-byte string
+	std::string tmpName = name;
+	std::wstring multibyteName = s2ws(tmpName);
+	
+	if (std::regex_match(multibyteName, ValidNick_Config.RegexTemplate))
 	{
 		if (IsAllowdedToReplaceUnderscoreSymbols())
 		{

--- a/ASAN/src/main.cpp
+++ b/ASAN/src/main.cpp
@@ -81,7 +81,7 @@ PLUGIN_EXPORT bool PLUGIN_CALL Load(void **ppData)
 
 		// ValidNick_Config
 		ValidNick_Config.EnableValidNickHOOK			= ASAN_DEFAULT_ENABLE_VALID_NICK_HOOK;
-		std::regex temp_regex_template(ASAN_DEFAULT_REGEX_TEMPLATE);
+		std::wregex temp_regex_template(s2ws(ASAN_DEFAULT_REGEX_TEMPLATE));
 		ValidNick_Config.RegexTemplate					= temp_regex_template;
 		ValidNick_Config.MaxAllowdedSpaces				= ASAN_DEFAULT_MAX_ALLOWDED_SPACES;
 

--- a/ASAN/src/main.cpp
+++ b/ASAN/src/main.cpp
@@ -207,10 +207,12 @@ MaxRepeatedNicks = %d\n\
 		Plugin_Config.Language = reader.GetInteger("ASAN_Plugin_Config", "Language", ASAN_DEFAULT_MAX_PLAYERS);
 
 		// ASAN_ValidNick_Settings
-		char RegexText[512];
+		std::string RegText = reader.Get("ASAN_ValidNick_Settings", "RegexTemplate", ASAN_DEFAULT_REGEX_TEMPLATE).c_str();
+		std::wstring multibyteRegText = s2ws(RegText);
+		
 		ValidNick_Config.EnableValidNickHOOK = reader.GetInteger("ASAN_ValidNick_Settings", "EnableValidNickHOOK", ASAN_DEFAULT_ENABLE_VALID_NICK_HOOK);
-		sprintf(RegexText, reader.Get("ASAN_ValidNick_Settings", "RegexTemplate", ASAN_DEFAULT_REGEX_TEMPLATE).c_str());
-		std::regex temp_regex_template(RegexText);
+		std::wregex temp_regex_template(multibyteRegText);
+		
 		ValidNick_Config.RegexTemplate = temp_regex_template;
 		ValidNick_Config.MaxAllowdedSpaces = reader.GetInteger("ASAN_ValidNick_Settings", "MaxAllowdedSpaces", ASAN_DEFAULT_MAX_ALLOWDED_SPACES);
 

--- a/ASAN/src/pawn_hook.cpp
+++ b/ASAN/src/pawn_hook.cpp
@@ -71,8 +71,12 @@ cell AMX_NATIVE_CALL ASAN_IsValidNickName(AMX *amx, cell *params)
 		return false;
 
 	int name_strlen = strlen(name);
-
-	if (!std::regex_match(name, ValidNick_Config.RegexTemplate) || name_strlen < NickLength_Config.MinNickLength || name_strlen > NickLength_Config.MaxNickLength || IsMaxRepeatedNicksError(name) || IsIgnoreRepeatedNicksCaseError(name))
+	
+	// Attempts to convert a character to a multi-byte string
+	std::string tmpName = name;
+	std::wstring multibyteName = s2ws(tmpName);
+	
+	if (!std::regex_match(multibyteName, ValidNick_Config.RegexTemplate) || name_strlen < NickLength_Config.MinNickLength || name_strlen > NickLength_Config.MaxNickLength || IsMaxRepeatedNicksError(name) || IsIgnoreRepeatedNicksCaseError(name))
 		return false;
 
 	if (IsAllowdedToReplaceUnderscoreSymbols() && !IsValidReplaceSpacesRules(name))


### PR DESCRIPTION
I tried to support the \u notation, which should be tested in the following regular expression without problem
#define ASAN_DEFAULT_REGEX_TEMPLATE					"(^[\\u3010\\u3011\\x21-\\x7e\\u4e00-\\u9fa5\\w]+$)"
【】你好abc0123