### PR TITLE
Fix incompatibility with FCNPC

### DIFF
--- a/ASAN/bin/pawn includes, regex, instructions/Russian text -  Русский текст/pawno/include/ASAN.inc
+++ b/ASAN/bin/pawn includes, regex, instructions/Russian text -  Русский текст/pawno/include/ASAN.inc
@@ -74,6 +74,10 @@ native ASAN_HOOK_DisconnectPlayer(playerid, reason);
 
 public OnPlayerConnect(playerid)
 {
+	// Исправляет несовместимость (краш) c FCNPC
+	if (IsPlayerNPC(playerid))
+		return 1;
+
 	new name[INCLUDE_ASAN_MAX_PLAYER_NAME + 1];
 	GetPlayerName(playerid, name, sizeof(name));
 	ASAN_HOOK_ConnectPlayer(playerid, name);


### PR DESCRIPTION
ASAN crashes FCNPC in this function because it probably changes the name of the NPC and FCNPC refers to a non-existent pointer in memory.